### PR TITLE
Add inspect linkages test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ test:
         - shapely
         - shapely.speedups._speedups
         - shapely.vectorized._vectorized
+    commands:
+        - conda inspect linkages -n _test shapely  # [linux]
 
 about:
     home: https://github.com/Toblerity/Shapely


### PR DESCRIPTION
Ideally we should always run this test when there is a `cython` extension.