### PR TITLE
update to 1.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.0" %}
+{% set version = "1.6.1" %}
 
 package:
   name: shapely
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/S/Shapely/Shapely-{{ version }}.tar.gz
-  sha256: 34d07cb277a5acf9ca5583a5b926678c58fb512d4fb4fcccbf3992e995b7ef60
+  sha256: 5ae137eb95ff615be399a285cf447913f845b0224e03d1167f638867eaccd0c7
 
 build:
   number: 0


### PR DESCRIPTION
```
1.6.1 (2017-09-01)
------------------

- Avoid ``STRTree`` crashes due to dangling references (#505) by maintaining
  references to added geometries.
- Reduce log level to debug when reporting on calls to ctypes ``CDLL()`` that
  don't succeed and are retried (#515).
- Clarification: applications like GeoPandas that need an empty geometry object
  should use ``BaseGeometry()`` instead of ``Point()`` or ``Polygon()``. An
  ``EmptyGeometry`` class has been added in the master development branch and
  will be available in the next non-bugfix release.
```