### PR TITLE
patch to find conda geos again :-(

### DIFF
--- a/recipe/find_conda_geos.patch
+++ b/recipe/find_conda_geos.patch
@@ -1,0 +1,92 @@
+--- Shapely-1.6.1.orig/shapely/geos.py	2017-09-01 15:12:40.000000000 -0300
++++ Shapely-1.6.1/shapely/geos.py	2017-09-05 21:11:24.329293827 -0300
+@@ -65,12 +65,13 @@
+     if len(geos_whl_so) == 1:
+         _lgeos = CDLL(geos_whl_so[0])
+         LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
++    elif os.getenv('CONDA_PREFIX', ''):
++        # conda package.
++        _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.so'))
+     else:
+         alt_paths = [
+             'libgeos_c.so.1',
+             'libgeos_c.so',
+-            # anaconda
+-            os.path.join(sys.prefix, "lib", "libgeos_c.so"),
+         ]
+         _lgeos = load_dll('geos_c', fallbacks=alt_paths)
+     free = load_dll('c').free
+@@ -84,7 +85,9 @@
+     if os.path.exists(geos_whl_dylib):
+         _lgeos = CDLL(geos_whl_dylib)
+         LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
+-
++    elif os.getenv('CONDA_PREFIX', ''):
++        # conda package.
++        _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.dylib'))
+     else:
+         if hasattr(sys, 'frozen'):
+             try:
+@@ -101,8 +104,6 @@
+                         os.path.join(sys._MEIPASS, 'libgeos_c.1.dylib'))
+         else:
+             alt_paths = [
+-                # anaconda
+-                os.path.join(sys.prefix, "lib", "libgeos_c.dylib"),
+                 # The Framework build from Kyng Chaos
+                 "/Library/Frameworks/GEOS.framework/Versions/Current/GEOS",
+                 # macports
+@@ -115,29 +116,31 @@
+     free.restype = None
+ 
+ elif sys.platform == 'win32':
+-    try:
+-        egg_dlls = os.path.abspath(
+-            os.path.join(os.path.dirname(__file__), 'DLLs'))
+-        if hasattr(sys, "frozen"):
+-            wininst_dlls = os.path.normpath(
+-                os.path.abspath(sys.executable + '../../DLLS'))
+-        else:
+-            wininst_dlls = os.path.abspath(os.__file__ + "../../../DLLs")
+-        original_path = os.environ['PATH']
+-        os.environ['PATH'] = "%s;%s;%s" % \
+-            (egg_dlls, wininst_dlls, original_path)
+-        _lgeos = load_dll("geos_c.dll", fallbacks=[
+-            os.path.join(sys.prefix, "Library", "lib", "geos_c.dll"),
+-        ])
+-    except (ImportError, WindowsError, OSError):
+-        raise
+-
+-    def free(m):
++    if os.getenv('CONDA_PREFIX', ''):
++        # conda package.
++        _lgeos = CDLL(os.path.join(sys.prefix, 'Library', 'bin', 'geos_c.dll'))
++    else:
+         try:
+-            cdll.msvcrt.free(m)
+-        except WindowsError:
+-            # XXX: See http://trac.gispython.org/projects/PCL/ticket/149
+-            pass
++            egg_dlls = os.path.abspath(
++                os.path.join(os.path.dirname(__file__), 'DLLs'))
++            if hasattr(sys, "frozen"):
++                wininst_dlls = os.path.normpath(
++                    os.path.abspath(sys.executable + '../../DLLS'))
++            else:
++                wininst_dlls = os.path.abspath(os.__file__ + "../../../DLLs")
++            original_path = os.environ['PATH']
++            os.environ['PATH'] = "%s;%s;%s" % \
++                (egg_dlls, wininst_dlls, original_path)
++            _lgeos = load_dll("geos_c.dll")
++        except (ImportError, WindowsError, OSError):
++            raise
++
++        def free(m):
++            try:
++                cdll.msvcrt.free(m)
++            except WindowsError:
++                # XXX: See http://trac.gispython.org/projects/PCL/ticket/149
++                pass
+ 
+ elif sys.platform == 'sunos5':
+     _lgeos = load_dll('geos_c', fallbacks=['libgeos_c.so.1', 'libgeos_c.so'])

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,11 @@ package:
 source:
   url: https://pypi.io/packages/source/S/Shapely/Shapely-{{ version }}.tar.gz
   sha256: 5ae137eb95ff615be399a285cf447913f845b0224e03d1167f638867eaccd0c7
+  patches:
+    - find_conda_geos.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
@dopplershift and @Chilipp this should allow for us to keep our local `geos` and have the conda package find the right one. If that works I'll send it upstream.

Closes https://github.com/conda-forge/cartopy-feedstock/issues/36