### PR TITLE
update 1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.1" %}
+{% set version = "1.6.2" %}
 
 package:
   name: shapely
@@ -6,12 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/S/Shapely/Shapely-{{ version }}.tar.gz
-  sha256: 5ae137eb95ff615be399a285cf447913f845b0224e03d1167f638867eaccd0c7
-  patches:
-    - find_conda_geos.patch
+  sha256: 0ed0db2ddc10e092de30c2ddae28cc8bd2543601b6af83877b76c3280f2537c6
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
```

1.6.2 (2017-10-26)
------------------

- Handle a ``TypeError`` that can occur when geometries are torn down (#473,
  #528).
- Splitting a linestring by one of its end points will now succeed instead of
  failing with a ``ValueError`` (#524, #533).
- Missing documentation of a geometry's ``overlaps`` predicate has been added
  (#522).
```