### PR TITLE
update to 1.6.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.2" %}
+{% set version = "1.6.3" %}
 
 package:
   name: shapely
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/S/Shapely/Shapely-{{ version }}.tar.gz
-  sha256: 0ed0db2ddc10e092de30c2ddae28cc8bd2543601b6af83877b76c3280f2537c6
+  sha256: 14152f111c7711fc6756fd538ec12fc8cdde7419f869b244922f71f61b2a6c6b
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
```
1.6.3 (2017-12-09)
------------------

- AttributeError is no longer raised when accessing __geo_interface__ of an
  empty polygon (#450).
- ``asShape`` now handles empty coordinates in mappings as ``shape`` does
  (#542). Please note that ``asShape`` is likely to be deprecated in a future
  version of Shapely.
- Check for length of LineString coordinates in speed mode, preventing crashes
  when using LineStrings with only one coordinate (#546).
```