### PR TITLE
omit speedups tests if module is unavailable

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,17 +1,11 @@
-set LIB=%LIBRARY_LIB%;%LIB%
-set LIBPATH=%LIBRARY_LIB%;%LIBPATH%
-set INCLUDE=%LIBRARY_INC%;%INCLUDE%;%RECIPE_DIR%
 
-set GEOS_LIBRARY_PATH=%LIBRARY_BIN%\geos_c.dll
-
-del /f shapely\speedups\_speedups.c
-del /f shapely\vectorized\_vectorized.c
+set GEOS_LIBRARY_PATH=%LIBRARY_LIB%
 
 "%PYTHON%" -m cython shapely\speedups\_speedups.pyx
 "%PYTHON%" -m cython shapely\vectorized\_vectorized.pyx
 
 "%PYTHON%" -m pip install --no-deps --ignore-installed --verbose . ^
-                          --global-option=build_ext ^
+                          --global-option="build_ext" ^
                           --global-option="-I%LIBRARY_INC%" ^
                           --global-option="-L%LIBRARY_LIB%" ^
                           --global-option="-lgeos_c"

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,8 +7,8 @@ set GEOS_LIBRARY_PATH=%LIBRARY_BIN%\geos_c.dll
 del /f shapely\speedups\_speedups.c
 del /f shapely\vectorized\_vectorized.c
 
-cython shapely\speedups\_speedups.pyx
-cython shapely\vectorized\_vectorized.pyx
+"%PYTHON%" -m cython shapely\speedups\_speedups.pyx
+"%PYTHON%" -m cython shapely\vectorized\_vectorized.pyx
 
 "%PYTHON%" -m pip install --no-deps --ignore-installed --verbose . ^
                           --global-option=build_ext ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,8 +1,5 @@
 
 set GEOS_LIBRARY_PATH=%LIBRARY_LIB%
 
-"%PYTHON%" -m cython shapely\speedups\_speedups.pyx
-"%PYTHON%" -m cython shapely\vectorized\_vectorized.pyx
-
 %PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgeos_c -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,9 +4,5 @@ set GEOS_LIBRARY_PATH=%LIBRARY_LIB%
 "%PYTHON%" -m cython shapely\speedups\_speedups.pyx
 "%PYTHON%" -m cython shapely\vectorized\_vectorized.pyx
 
-"%PYTHON%" -m pip install --no-deps --ignore-installed --verbose . ^
-                          --global-option="build_ext" ^
-                          --global-option="-I%LIBRARY_INC%" ^
-                          --global-option="-L%LIBRARY_LIB%" ^
-                          --global-option="-lgeos_c"
+%PYTHON% setup.py build_ext -I"%LIBRARY_INC%" -lgeos_c -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: f5307ee14ba4199f8bbcf6532ca33064661c1433960c432c84f0daa73b47ef9c
 
 build:
-  number: 7
+  number: 8
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.8.0" %}
+{% set version = "1.8.2" %}
 
 package:
   name: shapely
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/S/Shapely/Shapely-{{ version }}.tar.gz
-  sha256: f5307ee14ba4199f8bbcf6532ca33064661c1433960c432c84f0daa73b47ef9c
+  sha256: 572af9d5006fd5e3213e37ee548912b0341fb26724d6dc8a4e3950c10197ebb6
 
 build:
-  number: 8
+  number: 0
 
 requirements:
   build:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -12,7 +12,7 @@ print(f'python version: {py_version}')
 
 pytest_args = ['tests']
 
-try:
+if implementation != 'PyPy':
     from shapely import speedups
     import shapely.speedups._speedups
     import shapely.vectorized
@@ -22,8 +22,6 @@ try:
 
     speedups.enable()
     pytest_args.append('--with-speedups')
-except (ImportError, ModuleNotFoundError) as exp:
-    print(f"skipping speedups test due to {exp}")
 
 py.test.cmdline.main(pytest_args)
 

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -12,7 +12,7 @@ print(f'python version: {py_version}')
 
 pytest_args = ['tests']
 
-if implementation != 'PyPy':
+try:
     from shapely import speedups
     import shapely.speedups._speedups
     import shapely.vectorized
@@ -22,6 +22,8 @@ if implementation != 'PyPy':
 
     speedups.enable()
     pytest_args.append('--with-speedups')
+except (ImportError, ModuleNotFoundError) as exp:
+    print(f"skipping speedups test due to {exp}")
 
 py.test.cmdline.main(pytest_args)
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Attempting to get windows builds to work....  The present check assumes that `shapely.speedups` will exist when not build on `PyPy`.  So the differentiation in the windows build success is if the build was made with PyPy or not.  I am way off into the weeds on what I know about how this all works :(