### PR TITLE
Restore to bld.bat "pip install" with "--no-use-pep517"

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,14 +1,13 @@
 
-set GEOS_LIBRARY_PATH=%LIBRARY_BIN%
+:: set GEOS_LIBRARY_PATH=%LIBRARY_BIN%
 
 del /f shapely\speedups\_speedups.c
 del /f shapely\vectorized\_vectorized.c
 
-"%PYTHON%" setup.py build_ext ^
-    -I"%LIBRARY_INC%" ^
-    -lgeos_c ^
-    -L"%LIBRARY_LIB%" ^
-    install ^
-    --single-version-externally-managed ^
-    --record record.txt
+"%PYTHON%" -m pip install . -vv ^
+    --no-deps --ignore-installed --no-use-pep517 ^
+    --global-option=build_ext ^
+    --global-option="-I%LIBRARY_INC%" ^
+    --global-option="-L%LIBRARY_LIB%" ^
+    --global-option="-lgeos_c"
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 572af9d5006fd5e3213e37ee548912b0341fb26724d6dc8a4e3950c10197ebb6
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
---

When comparing source distributions on PyPI between Shapely-1.8.0 and Shapely-1.8.1 (and later), a `pyproject.toml` file was added for [PEP 517](https://peps.python.org/pep-0517/). While this is generally good, it seems to have broken the Windows build for Shapely-1.8 somehow (it could be a bug with Windows). This PR restores "pip install" with [`--no-use-pep517`](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-use-pep517) to force legacy behaviour (i.e. ignores `pyproject.toml`).

The other change is that `GEOS_LIBRARY_PATH` can be commented out for now, as this was only used by `shapely._buildcfg.py`, which is no longer used. (I think this is used for shapely-2.0, so keep it as a comment for now).